### PR TITLE
Add removable drives to sandbox

### DIFF
--- a/org.blender.Blender.json
+++ b/org.blender.Blender.json
@@ -12,7 +12,9 @@
         "--socket=x11",
         "--socket=pulseaudio",
         "--device=dri",
-        "--filesystem=home"
+        "--filesystem=home",
+        "--filesystem=/mnt",
+        "--filesystem=/media"
         ],
     "modules": [
         "shared-modules/glu/glu-9.0.0.json",


### PR DESCRIPTION
Reading and writing files on a USB drive is important for people using this app. I find the current flatpak gives me no way to access them.

This is my attempt to solve this. Please close if there's a better way to do this.